### PR TITLE
Edited license fields on pyproject.toml to reference our custom license

### DIFF
--- a/local-api/lib/pyproject.toml
+++ b/local-api/lib/pyproject.toml
@@ -5,7 +5,8 @@ description = "Formlabs Local API"
 authors = [
   {name = "Formlabs Support",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
+license = { file = "../../LICENSE.md" }
+classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Formlabs Local API"]
 requires-python = ">=3.9"

--- a/web-api/lib/pyproject.toml
+++ b/web-api/lib/pyproject.toml
@@ -3,7 +3,8 @@ name = "formlabs_web_api"
 version = "0.8.1"
 description = "Formlabs Web API"
 authors = ["Formlabs Support <team@openapitools.org>"]
-license = "NoLicense"
+license = { file = "../../LICENSE.md" }
+classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Formlabs Web API"]


### PR DESCRIPTION
Installation using `uv`, e.g. `uv run myscript.py` with
```
#!/usr/bin/env python3
# /// script
# dependencies = [
#   "formlabs-local-api @ git+https://github.com/Formlabs/formlabs-api-python.git#subdirectory=local-api/lib",
#   "rich>=13.0.0",
# ]
# ///
"""
```
fails with 
```
  × Failed to build `formlabs-local-api @
  │ git+https://github.com/Formlabs/formlabs-api-python.git@03bd1050fc5174cc47b0ef9faf201d8da76e9245#subdirectory=local-api/lib`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      configuration error: `project.license` must be valid exactly by one definition (0 matches
      found):

          - {type: string, format: 'SPDX'}
          - type: table
            keys:
              'file': {type: string}
            required: ['file']
          - type: table
            keys:
              'text': {type: string}
            required: ['text']

      DESCRIPTION:
          `Project license <https://peps.python.org/pep-0621/#license>`_.

      GIVEN VALUE:
          "NoLicense"

      OFFENDING RULE: 'oneOf'
      
      DEFINITION:
          {
              "oneOf": [
                  {
                      "type": "string",
                      "description": "An SPDX license identifier",
                      "format": "SPDX"
                  },
                  {
                      "type": "object",
                      "properties": {
                          "file": {
                              "type": "string",
                              "$$description": [
                                  "Relative path to the file (UTF-8) which contains the license
      for the",
                                  "project."
                              ]
                          }
                      },
                      "required": [
                          "file"
                      ]
                  },
                  {
                      "type": "object",
                      "properties": {
                          "text": {
                              "type": "string",
                              "$$description": [
                                  "The license of the project whose meaning is that of the",
                                  "`License field from the core metadata",
      
      "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                              ]
                          }
                      },
                      "required": [
                          "text"
                      ]
                  }
              ]
          }

      For more details about `format` see
      https://validate-pyproject.readthedocs.io/en/latest/api/validate_pyproject.formats.html
```

This PR resolves the `license` field on both existing `pyproject.toml` files to point to our custom license in `LICENSE.md`. This falls into the `object` type of the `oneOf` clause in the error and should resolve the issue.
