### PR TITLE
Fix license object path

### DIFF
--- a/local-api/lib/pyproject.toml
+++ b/local-api/lib/pyproject.toml
@@ -5,7 +5,7 @@ description = "Formlabs Local API"
 authors = [
   {name = "Formlabs Support",email = "team@openapitools.org"},
 ]
-license = { text = "Proprietary }
+license = { text = "Proprietary" }
 classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Formlabs Local API"]

--- a/local-api/lib/pyproject.toml
+++ b/local-api/lib/pyproject.toml
@@ -5,7 +5,7 @@ description = "Formlabs Local API"
 authors = [
   {name = "Formlabs Support",email = "team@openapitools.org"},
 ]
-license = { file = "../../LICENSE.md" }
+license = { text = "Proprietary }
 classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Formlabs Local API"]

--- a/web-api/lib/pyproject.toml
+++ b/web-api/lib/pyproject.toml
@@ -3,7 +3,7 @@ name = "formlabs_web_api"
 version = "0.8.1"
 description = "Formlabs Web API"
 authors = ["Formlabs Support <team@openapitools.org>"]
-license = { file = "../../LICENSE.md" }
+license = { text = "Proprietary }
 classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"

--- a/web-api/lib/pyproject.toml
+++ b/web-api/lib/pyproject.toml
@@ -3,7 +3,7 @@ name = "formlabs_web_api"
 version = "0.8.1"
 description = "Formlabs Web API"
 authors = ["Formlabs Support <team@openapitools.org>"]
-license = { text = "Proprietary }
+license = { text = "Proprietary" }
 classifiers = ["License :: Other/Proprietary License"]
 readme = "README.md"
 repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"


### PR DESCRIPTION
Moves to a `text` argument on `license` since the `LICENSE.md` is a few levels up and might not actually be distributed if the user is cloning just a subdir.